### PR TITLE
Ping template name change in Zabbix +4.x

### DIFF
--- a/zabbix-template/synology/Template Synology 6.xml
+++ b/zabbix-template/synology/Template Synology 6.xml
@@ -1054,7 +1054,7 @@ Canceling(10)</description>
             <macros/>
             <templates>
                 <template>
-                    <name>Template ICMP Ping</name>
+                    <name>Template Module ICMP Ping</name>
                 </template>
                 <template>
                     <name>Template SNMP Disks</name>


### PR DESCRIPTION
Ping template has been renamed to Template Module ICMP Ping in Zabbix +4.x